### PR TITLE
Update text.go

### DIFF
--- a/textcmd/text.go
+++ b/textcmd/text.go
@@ -69,7 +69,7 @@ func Commands(command string) *string {
 	case "!invite":
 		message = "`Ubiq Discord invite link:` <https://discord.gg/HF6vEGF>\n"
 	case "!miner":
-		message = "`Ubqminer:` <https://github.com/ubiq/ubqminer/releases> `PhoenixMiner 4.0b+:` <https://bitcointalk.org/index.php?topic=2647654.msg48314178#msg48314178> `TT-Miner:` <https://bitcointalk.org/index.php?topic=5025783.0> `Nanominer:` <https://github.com/nanopool/nanominer/releases/tag/v1.0.0>\n"
+		message = "`Ubqminer:` <https://github.com/ubiq/ubqminer/releases> `PhoenixMiner 4.0b+:` <https://bitcointalk.org/index.php?topic=2647654.msg48314178#msg48314178> `TT-Miner:` <https://bitcointalk.org/index.php?topic=5025783.0> `Nanominer:` <https://nanominer.org/>\n"
 	case "!mp", "!monetarypolicy":
 		message = "`Monetary policy and mining block rewards scheme in Ubiq:` <https://blog.ubiqsmart.com/ubiq-research-monetary-policy-2e27458983ec>\n"
 	case "!nucleus", "!transparency":


### PR DESCRIPTION
Fixes link to Nanominer and points to main Nanominer URL, where current version (1.21) is provided. Old link pointed to initial version that has since been superseded. The current link is maintained by Nanominer, and any future miner revisions should be automatically posted there - no longer requiring revision of this command.