### PR TITLE
remove !verify

### DIFF
--- a/textcmd/text.go
+++ b/textcmd/text.go
@@ -103,15 +103,6 @@ func Commands(command string) *string {
 		message = "`Solidity documentation:` <http://solidity.readthedocs.io>\n"
 	case "!stats":
 		message = "`Ubiq network stats:` <https://ubiq.gojupiter.tech>\n"
-	case "!verify", "!verified":
-		message = "__**Verified**__"
-		message += "\n"
-		message += "You can request to be Verified in the <#348034489655623680> channel. This allows us to see who is a community member and lets you send messages.\n\n"
-		message += "This policy is in place to prevent bots, spammers and scammers.\n"
-		message += "To get Verified:\n"
-		message += "a) Mention you would like to be Verified in the <#348034489655623680> channel. Mentioning where you came from and how you found out about Ubiq helps too.\n"
-		message += "b) Only people with a profile pic are allowed to be Verified. It doesn't have to be your actual photo. It can be any appropriate image you like.\n\n"
-		message += "THIS IS NOT KYC - no personally identifiable information is required to join this Discord."
 	case "!wallet":
 		message = "`Web:` <https://pyrus.ubiqsmart.com> `Web2:` <https://myetherwallet.com> `GUI:` <https://github.com/ubiq/fusion/releases> `CLI:` <https://github.com/ubiq/go-ubiq/releases>\n"
 	case "!website", "!site":


### PR DESCRIPTION
TARS !verify is deprecated now that Server Captcha Bot reissues a notice and new Captcha with the !verify cmd.
This PR deletes the TARS !verify cmd